### PR TITLE
PN-17480: fix DecodingException on timeline deserialization by enabling useOneOfInterfaces in pn-delivery-push codegen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,9 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <inputSpec>https://raw.githubusercontent.com/pagopa/pn-delivery-push/b9fd2f4a4bfb67b7afd2a7cc16520274cf90b778/docs/openapi/api-private.yaml</inputSpec>
+                            <!-- WORKAROUND: i DTO generati non estendono la classe base, causando
+                                 InvalidTypeIdException.-->
+                            <templateDirectory>${project.basedir}/src/main/resources/templates/7.12.0/client</templateDirectory>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/pom.xml
+++ b/pom.xml
@@ -474,9 +474,6 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <inputSpec>https://raw.githubusercontent.com/pagopa/pn-delivery-push/b9fd2f4a4bfb67b7afd2a7cc16520274cf90b778/docs/openapi/api-private.yaml</inputSpec>
-                            <!-- WORKAROUND: i DTO generati non estendono la classe base, causando
-                                 InvalidTypeIdException.-->
-                            <templateDirectory>${project.basedir}/src/main/resources/templates/7.12.0/client</templateDirectory>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>
@@ -487,6 +484,7 @@
                                 <useJakartaEe>true</useJakartaEe>
                                 <swaggerAnnotations>false</swaggerAnnotations>
                                 <openApiNullable>false</openApiNullable>
+                                <useOneOfInterfaces>true</useOneOfInterfaces>
                             </configOptions>
                             <modelPackage>${project.groupId}.radd.alt.generated.openapi.msclient.pndeliverypush.v1.dto</modelPackage>
                             <apiPackage>${project.groupId}.radd.alt.generated.openapi.msclient.pndeliverypush.v1.api

--- a/src/test/java/it/pagopa/pn/radd/middleware/msclient/PnDeliveryPushClientTest.java
+++ b/src/test/java/it/pagopa/pn/radd/middleware/msclient/PnDeliveryPushClientTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -154,5 +155,26 @@ class PnDeliveryPushClientTest extends BaseTest.WithMockServer {
             fail("Badly type exception");
             return Mono.empty();
         }).blockFirst();
+    }
+
+    /**
+     * Regression test — PN-19039 / errore del 2026-04-15 in dev.
+     *
+     * Verifica che la risposta di pn-delivery-push con un elemento di timeline con
+     * categoryType = "VALIDATE_NORMALIZE_ADDRESSES_REQUEST" venga deserializzata
+     * correttamente senza eccezioni.
+     *
+     * Prima del fix (override di typeInfoAnnotation.mustache) il DTO generato
+     * (ValidateNormalizeAddressDetailsDto) non estendeva TimelineElementDetailsV28Dto,
+     * causando InvalidTypeIdException avvolto in DecodingException.
+     */
+    @Test
+    void testGetNotificationHistory_timelineWithValidateNormalizeAddresses_returnsSuccessfully() {
+        String iun = "YDPM-EKJA-DQGQ-202604-E-1";
+
+        StepVerifier.create(pnDeliveryPushClient.getNotificationHistory(iun))
+                .expectNextMatches(response ->
+                        NotificationStatusV26Dto.ACCEPTED == response.getNotificationStatus())
+                .verifyComplete();
     }
 }

--- a/src/test/java/it/pagopa/pn/radd/middleware/msclient/PnDeliveryPushClientTest.java
+++ b/src/test/java/it/pagopa/pn/radd/middleware/msclient/PnDeliveryPushClientTest.java
@@ -158,14 +158,15 @@ class PnDeliveryPushClientTest extends BaseTest.WithMockServer {
     }
 
     /**
-     * Regression test — PN-19039 / errore del 2026-04-15 in dev.
+     * Regression test — PN-17480 / errore del 2026-04-15 in dev.
      *
      * Verifica che la risposta di pn-delivery-push con un elemento di timeline con
      * categoryType = "VALIDATE_NORMALIZE_ADDRESSES_REQUEST" venga deserializzata
      * correttamente senza eccezioni.
      *
-     * Prima del fix (override di typeInfoAnnotation.mustache) il DTO generato
-     * (ValidateNormalizeAddressDetailsDto) non estendeva TimelineElementDetailsV28Dto,
+     * Prima del fix (useOneOfInterfaces=true nella generazione del client pn-delivery-push)
+     * il generatore emetteva @JsonTypeInfo/@JsonSubTypes sulla classe base, ma i DTO concreti
+     * (es. ValidateNormalizeAddressDetailsDto) non estendevano TimelineElementDetailsV28Dto,
      * causando InvalidTypeIdException avvolto in DecodingException.
      */
     @Test

--- a/src/test/resources/PnDeliveryPushClientTest-webhook.json
+++ b/src/test/resources/PnDeliveryPushClientTest-webhook.json
@@ -202,5 +202,31 @@
         ]
       }
     }
+  },
+  {
+    "httpRequest": {
+      "path": "/delivery-push-private/YDPM-EKJA-DQGQ-202604-E-1/history",
+      "method": "GET"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "headers": {
+        "content-type": ["application/json"]
+      },
+      "body": {
+        "notificationStatus": "ACCEPTED",
+        "notificationStatusHistory": [],
+        "timeline": [
+          {
+            "elementId": "VALIDATE_NORMALIZE_ADDRESSES_REQUEST.IUN_YDPM-EKJA-DQGQ-202604-E-1",
+            "timestamp": "2026-04-15T10:09:11Z",
+            "category": "VALIDATE_NORMALIZE_ADDRESSES_REQUEST",
+            "details": {
+              "categoryType": "VALIDATE_NORMALIZE_ADDRESSES_REQUEST"
+            }
+          }
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
…peInfoAnnotation mustache template for pn-delivery-push client generation