### PR TITLE
PN-19713: add resolvedBasepath parameter to startTransaction public s…

### DIFF
--- a/src/main/java/it/pagopa/pn/radd/rest/radd/fsu/ActPrivateRestV1Controller.java
+++ b/src/main/java/it/pagopa/pn/radd/rest/radd/fsu/ActPrivateRestV1Controller.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.radd.rest.radd.fsu;
 
 import it.pagopa.pn.radd.alt.generated.openapi.server.v1.api.ActOperationsApi;
 import it.pagopa.pn.radd.alt.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.radd.config.PnRaddFsuConfig;
 import it.pagopa.pn.radd.services.radd.fsu.v1.ActService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,9 +16,11 @@ public class ActPrivateRestV1Controller implements ActOperationsApi {
 
 
     ActService actService;
+    private final PnRaddFsuConfig pnRaddFsuConfig;
 
-    public ActPrivateRestV1Controller(ActService actService) {
+    public ActPrivateRestV1Controller(ActService actService, PnRaddFsuConfig pnRaddFsuConfig) {
         this.actService = actService;
+        this.pnRaddFsuConfig = pnRaddFsuConfig;
     }
 
     @Override
@@ -28,7 +31,7 @@ public class ActPrivateRestV1Controller implements ActOperationsApi {
     @Override
     public Mono<ResponseEntity<StartTransactionResponse>> startActTransaction(String uid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, Mono<ActStartTransactionRequest> actStartTransactionRequest, String xPagopaPnCxRole, ServerWebExchange exchange) {
         return actStartTransactionRequest
-                .zipWhen(request -> actService.startTransaction(uid, xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxRole, request), (req, resp) -> resp)
+                .zipWhen(request -> actService.startTransaction(uid, xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxRole, pnRaddFsuConfig.getApplicationBasepath(), request), (req, resp) -> resp)
                 .map(m -> ResponseEntity.status(HttpStatus.OK).body(m));
     }
 

--- a/src/main/java/it/pagopa/pn/radd/rest/radd/fsu/AorPrivateRestV1Controller.java
+++ b/src/main/java/it/pagopa/pn/radd/rest/radd/fsu/AorPrivateRestV1Controller.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.radd.rest.radd.fsu;
 
 import it.pagopa.pn.radd.alt.generated.openapi.server.v1.api.AorOperationsApi;
 import it.pagopa.pn.radd.alt.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.radd.config.PnRaddFsuConfig;
 import it.pagopa.pn.radd.services.radd.fsu.v1.AorService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +14,11 @@ import reactor.core.publisher.Mono;
 @RestController
 public class AorPrivateRestV1Controller implements AorOperationsApi {
     private final AorService aorService;
+    private final PnRaddFsuConfig pnRaddFsuConfig;
 
-    public AorPrivateRestV1Controller(AorService aorService) {
+    public AorPrivateRestV1Controller(AorService aorService, PnRaddFsuConfig pnRaddFsuConfig) {
         this.aorService = aorService;
+        this.pnRaddFsuConfig = pnRaddFsuConfig;
     }
 
 
@@ -42,7 +45,7 @@ public class AorPrivateRestV1Controller implements AorOperationsApi {
     @Override
     public Mono<ResponseEntity<StartTransactionResponse>> startAorTransaction(String uid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, Mono<AorStartTransactionRequest> aorStartTransactionRequest, String xPagopaPnCxRole, ServerWebExchange exchange) {
         return aorStartTransactionRequest
-                .zipWhen(req -> aorService.startTransaction(uid, req, xPagopaPnCxType, xPagopaPnCxId,xPagopaPnCxRole), (req, resp) -> resp)
+                .zipWhen(req -> aorService.startTransaction(uid, pnRaddFsuConfig.getApplicationBasepath(), req, xPagopaPnCxType, xPagopaPnCxId, xPagopaPnCxRole), (req, resp) -> resp)
                 .map(m -> ResponseEntity.status(HttpStatus.OK).body(m));
     }
 }

--- a/src/main/java/it/pagopa/pn/radd/services/radd/fsu/v1/ActService.java
+++ b/src/main/java/it/pagopa/pn/radd/services/radd/fsu/v1/ActService.java
@@ -139,7 +139,7 @@ public class ActService extends BaseService {
                 .doOnError(err -> log.error(err.getMessage()));
     }
 
-    public Mono<StartTransactionResponse> startTransaction(String uid, String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxRole, ActStartTransactionRequest request) {
+    public Mono<StartTransactionResponse> startTransaction(String uid, String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxRole, String resolvedBasepath, ActStartTransactionRequest request) {
         PnRaddAltAuditLog pnRaddAltAuditLog = PnRaddAltAuditLog.builder()
                 .eventType(PnAuditLogEventType.AUD_RADD_ACTTRAN)
                 .msg(START_ACT_START_TRANSACTION)

--- a/src/main/java/it/pagopa/pn/radd/services/radd/fsu/v1/AorService.java
+++ b/src/main/java/it/pagopa/pn/radd/services/radd/fsu/v1/AorService.java
@@ -134,7 +134,7 @@ public class AorService extends BaseService {
                 );
     }
 
-    public Mono<StartTransactionResponse> startTransaction(String uid, AorStartTransactionRequest request, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, String xPagopaPnCxRole) {
+    public Mono<StartTransactionResponse> startTransaction(String uid, String resolvedBasepath, AorStartTransactionRequest request, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, String xPagopaPnCxRole) {
         PnRaddAltAuditLog pnRaddAltAuditLog = PnRaddAltAuditLog.builder()
                 .eventType(PnAuditLogEventType.AUD_RADD_AORTRAN)
                 .msg(START_AOR_START_TRANSACTION)

--- a/src/test/java/it/pagopa/pn/radd/rest/radd/fsu/ActPrivateRestV1ControllerTest.java
+++ b/src/test/java/it/pagopa/pn/radd/rest/radd/fsu/ActPrivateRestV1ControllerTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.radd.rest.radd.fsu;
 
 import it.pagopa.pn.radd.alt.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.radd.config.PnRaddFsuConfig;
 import it.pagopa.pn.radd.services.radd.fsu.v1.ActService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -29,6 +30,9 @@ class ActPrivateRestV1ControllerTest {
 
     @MockitoBean
     private ActService actService;
+
+    @MockitoBean
+    private PnRaddFsuConfig pnRaddFsuConfig;
 
     @Test
     void actInquiryTest() {
@@ -126,7 +130,7 @@ class ActPrivateRestV1ControllerTest {
 
         String path = "/radd-net/api/v1/act/transaction/start";
         Mockito.when(actService
-                .startTransaction(Mockito.anyString(), Mockito.any(), Mockito.any(),Mockito.any(), Mockito.any())
+                .startTransaction(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
         ).thenReturn(Mono.just(response));
 
         webTestClient.post()

--- a/src/test/java/it/pagopa/pn/radd/rest/radd/fsu/AorPrivateRestV1ControllerTest.java
+++ b/src/test/java/it/pagopa/pn/radd/rest/radd/fsu/AorPrivateRestV1ControllerTest.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.radd.rest.radd.fsu;
 
 
 import it.pagopa.pn.radd.alt.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.radd.config.PnRaddFsuConfig;
 import it.pagopa.pn.radd.services.radd.fsu.v1.AorService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -28,6 +29,9 @@ class AorPrivateRestV1ControllerTest {
 
     @MockitoBean
     private AorService aorService;
+
+    @MockitoBean
+    private PnRaddFsuConfig pnRaddFsuConfig;
 
     @Test
     void aorInquiryTest() {
@@ -70,7 +74,7 @@ class AorPrivateRestV1ControllerTest {
 
         String path = "/radd-net/api/v1/aor/transaction/start";
         Mockito.when(aorService
-                .startTransaction(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
+                .startTransaction(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
         ).thenReturn(Mono.just(response));
 
         webTestClient.post()

--- a/src/test/java/it/pagopa/pn/radd/services/radd/fsu/v1/ActServiceStartTransactionTest.java
+++ b/src/test/java/it/pagopa/pn/radd/services/radd/fsu/v1/ActServiceStartTransactionTest.java
@@ -187,7 +187,7 @@ class ActServiceStartTransactionTest {
                .thenReturn(Mono.just(raddTransactionEntity));
         Mockito.when(pnDeliveryPushClient.getLegalFact(any(), any(), any())).thenReturn(Mono.just(legalFactDownloadMetadataResponseDto));
         Mockito.when(raddTransactionDAOImpl.updateZipAttachments(any(), any())).thenReturn(Mono.just(raddTransactionEntity));
-        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER",request).block();
+        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
         assertNotNull(startTransactionResponse);
         assertEquals(StartTransactionResponseStatus.CodeEnum.NUMBER_0, startTransactionResponse.getStatus().getCode());
         assertEquals(Const.OK, startTransactionResponse.getStatus().getMessage());
@@ -228,7 +228,7 @@ class ActServiceStartTransactionTest {
 
         Mockito.when(pnTimelineServiceClient.getCancellationRequest(any())).thenReturn(Mono.empty());
 
-        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request).block();
+        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
         assertNotNull(startTransactionResponse);
         assertEquals(StartTransactionResponseStatus.CodeEnum.NUMBER_2, startTransactionResponse.getStatus().getCode());
         assertEquals(new BigDecimal(20), startTransactionResponse.getStatus().getRetryAfter());
@@ -247,7 +247,7 @@ class ActServiceStartTransactionTest {
         Mockito.when(raddTransactionDAOImpl.updateStatus(any(), any())).thenReturn(Mono.just(new RaddTransactionEntity()));
 
 
-        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request).block();
+        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
         assertNotNull(startTransactionResponse);
         assertEquals(StartTransactionResponseStatus.CodeEnum.NUMBER_99, startTransactionResponse.getStatus().getCode());
         assertEquals(ExceptionTypeEnum.IUN_NOT_FOUND.getMessage(), startTransactionResponse.getStatus().getMessage());
@@ -267,7 +267,7 @@ class ActServiceStartTransactionTest {
         Mockito.when(raddTransactionDAOImpl.updateStatus(any(), any())).thenReturn(Mono.just(new RaddTransactionEntity()));
 
 
-        StepVerifier.create(actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request))
+        StepVerifier.create(actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request))
                     .expectError(PnRaddException.class).verify();
         ExpectedLoggingAssertions.assertThat(logging).hasInfoMessage("[AUD_RADD_ACTTRAN] BEFORE - Start ACT startTransaction - uid=test cxId=cxId cxType=PG operationId=Id iun=null");
         ExpectedLoggingAssertions.assertThat(logging).hasErrorMessage("[AUD_RADD_ACTTRAN] FAILURE - End ACT startTransaction with error Internal server Error - uid=test cxId=cxId cxType=PG operationId=Id recipientInternalId=recipientTaxIdResult delegateInternalId=delegateTaxIdResult iun=null");
@@ -293,7 +293,7 @@ class ActServiceStartTransactionTest {
         Mockito.when(raddTransactionDAOImpl.updateStatus(any(), any())).thenReturn(Mono.just(new RaddTransactionEntity()));
 
 
-        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request).block();
+        StartTransactionResponse startTransactionResponse = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
         assertNotNull(startTransactionResponse);
         assertEquals(StartTransactionResponseStatus.CodeEnum.NUMBER_5, startTransactionResponse.getStatus().getCode());
         assertEquals(ExceptionTypeEnum.TRANSACTION_ALREADY_EXIST.getMessage(), startTransactionResponse.getStatus().getMessage());
@@ -306,7 +306,7 @@ class ActServiceStartTransactionTest {
         ActStartTransactionRequest request = createActStartTransactionRequest();
         request.setIun("FakeIun");
 
-        StepVerifier.create(actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request))
+        StepVerifier.create(actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request))
                     .expectError(PnInvalidInputException.class).verify();
         ExpectedLoggingAssertions.assertThat(logging).hasInfoMessage("[AUD_RADD_ACTTRAN] BEFORE - Start ACT startTransaction - uid=test cxId=cxId cxType=PG operationId=Id iun=FakeIun");
     }
@@ -340,7 +340,7 @@ class ActServiceStartTransactionTest {
                 .thenReturn(Mono.error(new RaddGenericException(ExceptionTypeEnum.TRANSACTION_NOT_EXIST)));
 
         StartTransactionResponse response = actService.startTransaction(
-                "test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request).block();
+                "test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
 
         assertNotNull(response);
         assertEquals(StartTransactionResponseStatus.CodeEnum.NUMBER_4, response.getStatus().getCode());
@@ -380,7 +380,7 @@ class ActServiceStartTransactionTest {
 
 
         StartTransactionResponse response = actService.startTransaction(
-                "test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request).block();
+                "test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
 
         assertNotNull(response);
         // code=4 perché documentsAvailable=false
@@ -424,7 +424,7 @@ class ActServiceStartTransactionTest {
 
         ActStartTransactionRequest request = createActStartTransactionRequest();
 
-        StepVerifier.create(actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request))
+        StepVerifier.create(actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request))
                 .assertNext(response -> {
                     assertNotNull(response.getDownloadUrlList());
                     assertFalse(response.getDownloadUrlList().isEmpty());
@@ -455,7 +455,7 @@ class ActServiceStartTransactionTest {
         Mockito.when(pnDeliveryPushClient.getLegalFact(any(), any(), any()))
                .thenReturn(Mono.error(new RaddGenericException(ExceptionTypeEnum.DOCUMENT_UNAVAILABLE)));
 
-        StartTransactionResponse response = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", request).block();
+        StartTransactionResponse response = actService.startTransaction("test", "cxId", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", request).block();
 
         assertNotNull(response);
         assertEquals(StartTransactionResponseStatus.CodeEnum.NUMBER_4, response.getStatus().getCode());

--- a/src/test/java/it/pagopa/pn/radd/services/radd/fsu/v1/ActServiceTest.java
+++ b/src/test/java/it/pagopa/pn/radd/services/radd/fsu/v1/ActServiceTest.java
@@ -152,7 +152,7 @@ class ActServiceTest  {
         TransactionData transactionData = new TransactionData();
         transactionData.setQrCode("qrcode");
         transactionData.setIun("iun");
-        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", startTransactionRequest) )
+        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", startTransactionRequest) )
                     .expectError(PnInvalidInputException.class).verify();
     }
 
@@ -169,7 +169,7 @@ class ActServiceTest  {
         TransactionData transactionData = new TransactionData();
         transactionData.setQrCode("qrcode");
         transactionData.setIun("iun");
-        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", startTransactionRequest) )
+        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", startTransactionRequest) )
                     .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                                                      "Campo fileKey obbligatorio mancante".equals(throwable.getMessage()))
                     .verify();
@@ -189,7 +189,7 @@ class ActServiceTest  {
         TransactionData transactionData = new TransactionData();
         transactionData.setQrCode("qrcode");
         transactionData.setIun("iun");
-        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", startTransactionRequest) )
+        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", startTransactionRequest) )
                     .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                                                      "Campo versionToken obbligatorio mancante".equals(throwable.getMessage()))
                     .verify();
@@ -208,7 +208,7 @@ class ActServiceTest  {
         TransactionData transactionData = new TransactionData();
         transactionData.setQrCode("qrcode");
         transactionData.setIun("iun");
-        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD", startTransactionRequest) )
+        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD", "http://localhost", startTransactionRequest) )
                     .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                                                      "Campo fileKey inaspettato".equals(throwable.getMessage()))
                     .verify();
@@ -227,7 +227,7 @@ class ActServiceTest  {
         TransactionData transactionData = new TransactionData();
         transactionData.setQrCode("qrcode");
         transactionData.setIun("iun");
-        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD", startTransactionRequest) )
+        StepVerifier.create(actService.startTransaction("id",  "cxId",CxTypeAuthFleet.PG, "RADD", "http://localhost", startTransactionRequest) )
                     .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                                                      "Campo versionToken inaspettato".equals(throwable.getMessage()))
                     .verify();
@@ -240,7 +240,7 @@ class ActServiceTest  {
         startTransactionRequest.setFileKey("fileKey");
         startTransactionRequest.setChecksum("checksum");
         startTransactionRequest.setVersionToken("versionToken");
-        Mono<StartTransactionResponse> response = actService.startTransaction("test", "123", CxTypeAuthFleet.PG, "RADD_UPLOADER", startTransactionRequest);
+        Mono<StartTransactionResponse> response = actService.startTransaction("test", "123", CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", startTransactionRequest);
         response.onErrorResume(PnInvalidInputException.class, exception -> {
             log.info("Exception {}", exception.getReason());
             assertEquals("Operation id non valorizzato", exception.getReason());
@@ -250,7 +250,7 @@ class ActServiceTest  {
         startTransactionRequest.setOperationId("TestOperationId");
 
 
-        Mono<StartTransactionResponse> response2 = actService.startTransaction("test", "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", startTransactionRequest);
+        Mono<StartTransactionResponse> response2 = actService.startTransaction("test", "cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", startTransactionRequest);
         response2.onErrorResume(PnInvalidInputException.class, exception -> {
             assertEquals("Codice fiscale non valorizzato", exception.getReason());
             return Mono.empty();
@@ -258,7 +258,7 @@ class ActServiceTest  {
 
         startTransactionRequest.setRecipientTaxId("abc342psoeo22");
 
-        Mono<StartTransactionResponse> response3 = actService.startTransaction("test","cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", startTransactionRequest);
+        Mono<StartTransactionResponse> response3 = actService.startTransaction("test","cxId",CxTypeAuthFleet.PG, "RADD_UPLOADER", "http://localhost", startTransactionRequest);
         response3.onErrorResume(PnInvalidInputException.class, exception -> {
             assertEquals("Né IUN nè QrCode valorizzati", exception.getReason());
             return Mono.empty();
@@ -287,7 +287,7 @@ class ActServiceTest  {
         when(pnRaddFsuConfig.getMaxPrintRequests()).thenReturn(1);
         when(raddTransactionDAOImpl.countFromIunAndStatus(any(),any())).thenReturn(Mono.just(1));
 
-        StartTransactionResponse response = actService.startTransaction("id","cxId",CxTypeAuthFleet.PF, "RADD_UPLOADER", startTransactionRequest).block();
+        StartTransactionResponse response = actService.startTransaction("id","cxId",CxTypeAuthFleet.PF, "RADD_UPLOADER", "http://localhost", startTransactionRequest).block();
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isNotNull();
         assertThat(response.getStatus().getCode()).isEqualTo(StartTransactionResponseStatus.CodeEnum.NUMBER_3);

--- a/src/test/java/it/pagopa/pn/radd/services/radd/fsu/v1/AorServiceTest.java
+++ b/src/test/java/it/pagopa/pn/radd/services/radd/fsu/v1/AorServiceTest.java
@@ -113,18 +113,18 @@ class AorServiceTest {
         request.setFileKey("test");
         request.setChecksum("checksum");
         request.setVersionToken("versionToken");
-        StepVerifier.create(aorService.startTransaction("uid", request, CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)))
+        StepVerifier.create(aorService.startTransaction("uid", "http://localhost", request, CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)))
                 .expectError(PnInvalidInputException.class).verify();
 
         request.setOperationId("1234AOR");
-        StepVerifier.create(aorService.startTransaction("uid", request, it.pagopa.pn.radd.alt.generated.openapi.server.v1.dto.CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)))
+        StepVerifier.create(aorService.startTransaction("uid", "http://localhost", request, it.pagopa.pn.radd.alt.generated.openapi.server.v1.dto.CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)))
                 .expectError(PnInvalidInputException.class).verify();
     }
 
     @Test
     void testStartTransactionReturnErrorRaddUploaderWithoutFileKey(){
         AorStartTransactionRequest request = new AorStartTransactionRequest();
-        StepVerifier.create(aorService.startTransaction("uid",request,CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)) )
+        StepVerifier.create(aorService.startTransaction("uid", "http://localhost", request, CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)) )
                 .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                         "Campo fileKey obbligatorio mancante".equals(throwable.getMessage()))
                 .verify();
@@ -132,7 +132,7 @@ class AorServiceTest {
 
     @Test
     void testStartTransactionReturnErrorRaddStandardWithFileKey(){
-        StepVerifier.create(aorService.startTransaction("uid",startTransactionRequest,CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_STANDARD)))
+        StepVerifier.create(aorService.startTransaction("uid", "http://localhost", startTransactionRequest,CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_STANDARD)))
                 .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                         "Campo fileKey inaspettato".equals(throwable.getMessage()))
                 .verify();
@@ -143,7 +143,7 @@ class AorServiceTest {
         AorStartTransactionRequest request = new AorStartTransactionRequest();
         request.setFileKey("fileKey");
         request.setChecksum("checksum");
-        StepVerifier.create(aorService.startTransaction("uid",request,CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)) )
+        StepVerifier.create(aorService.startTransaction("uid", "http://localhost", request, CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_UPLOADER)) )
                 .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                         "Campo versionToken obbligatorio mancante".equals(throwable.getMessage()))
                 .verify();
@@ -153,7 +153,7 @@ class AorServiceTest {
     void testStartTransactionReturnErrorRaddStandardWithVerionToken(){
         AorStartTransactionRequest request = new AorStartTransactionRequest();
         request.setVersionToken("versionToken");
-        StepVerifier.create(aorService.startTransaction("uid",request,CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_STANDARD)))
+        StepVerifier.create(aorService.startTransaction("uid", "http://localhost", request, CxTypeAuthFleet.valueOf("PF"), "xPagopaPnCxId",String.valueOf(RaddRole.RADD_STANDARD)))
                 .expectErrorMatches(throwable -> throwable instanceof PnRaddBadRequestException &&
                         "Campo versionToken inaspettato".equals(throwable.getMessage()))
                 .verify();
@@ -199,7 +199,7 @@ class AorServiceTest {
 
         Mockito.when(pnRaddFsuConfig.getApplicationBasepath()).thenReturn("123");
 
-        StartTransactionResponse response = this.aorService.startTransaction("uid", startTransactionRequest, CxTypeAuthFleet.valueOf("PF"), "1",String.valueOf(RaddRole.RADD_UPLOADER)).block();
+        StartTransactionResponse response = this.aorService.startTransaction("uid", "http://localhost", startTransactionRequest, CxTypeAuthFleet.valueOf("PF"), "1",String.valueOf(RaddRole.RADD_UPLOADER)).block();
 
         assertNotNull(response);
         // assertNotNull(response.getUrlList());


### PR DESCRIPTION
…ignatures

- Add `String resolvedBasepath` to the public signatures of `ActService.startTransaction` and `AorService.startTransaction`.
- Controllers inject `PnRaddFsuConfig` and pass `getApplicationBasepath()` as a temporary stub until header-based resolution is implemented. Internal methods and URL generation logic are unchanged.
- Update all affected test call sites with a placeholder value.